### PR TITLE
Add Parsec as a key backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,21 @@ jobs:
         - name: Run clippy
           run: |
               cargo clippy --features key_tpm,key_openssl_pkey --all
-
+    
+    test_parsec:
+        name: Test Parsec integration
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - run: |
+              curl -s -N -L https://github.com/parallaxsecond/parsec/releases/download/1.0.0/quickstart-1.0.0-linux_x86.tar.gz | tar xz --strip-components=1
+              export PARSEC_SERVICE_ENDPOINT=unix:$(pwd)/parsec.sock
+              ./parsec &
+              sleep 5
+              ./parsec-tool ping
+              cargo test --features key_parsec
+              pkill parsec
+              
     clippy:
         name: Clippy
         runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "1.5", default_features = false }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "6.1", optional = true }
+parsec-client = { version = "0.13.0", optional = true }
 
 [dependencies.serde]
 version = "1.0"
@@ -28,3 +29,4 @@ hex = "0.4"
 default = ["key_openssl_pkey"]
 key_openssl_pkey = ["openssl"]
 key_tpm = ["tss-esapi", "openssl"]
+key_parsec = ["parsec-client"]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -16,6 +16,8 @@ pub use self::openssl::Openssl;
 
 #[cfg(feature = "key_openssl_pkey")]
 mod openssl_pkey;
+#[cfg(feature = "key_parsec")]
+pub mod parsec;
 #[cfg(feature = "key_tpm")]
 pub mod tpm;
 

--- a/src/crypto/parsec.rs
+++ b/src/crypto/parsec.rs
@@ -1,0 +1,115 @@
+//! PARSEC implementation for cryptography
+
+use crate::{
+    crypto::{MessageDigest, SignatureAlgorithm, SigningPrivateKey, SigningPublicKey},
+    error::CoseError,
+};
+use parsec_client::{
+    auth::Authentication,
+    core::interface::{
+        operations::{
+            psa_algorithm::{Algorithm, AsymmetricSignature, Hash, SignHash},
+            psa_key_attributes::Attributes,
+        },
+        requests::ResponseStatus,
+    },
+    error::{ClientErrorKind, Error},
+    BasicClient,
+};
+
+/// A reference to a PARSEC service-backed key
+pub struct ParsecKey {
+    parsec_client: BasicClient,
+    name: String,
+    algorithm: AsymmetricSignature,
+    parameters: (SignatureAlgorithm, MessageDigest),
+}
+
+impl ParsecKey {
+    /// Create a new [ParsecKey] based on its name within the Parsec
+    /// service.
+    pub fn new(name: String, parsec_auth: Option<Authentication>) -> Result<ParsecKey, CoseError> {
+        let parsec_client = match parsec_auth {
+            None => BasicClient::new(None)?,
+            Some(auth) => {
+                let mut client = BasicClient::new_naked();
+                client.set_auth_data(auth);
+                client.set_default_provider()?;
+                client
+            }
+        };
+
+        let keys = parsec_client.list_keys()?;
+        let key = keys
+            .into_iter()
+            .find(|key| key.name == name)
+            .ok_or(Error::Client(ClientErrorKind::NotFound))?;
+        let (parameters, algorithm) = attrs_to_params(&key.attributes)?;
+
+        Ok(ParsecKey {
+            parsec_client,
+            name,
+            algorithm,
+            parameters,
+        })
+    }
+}
+
+fn attrs_to_params(
+    attrs: &Attributes,
+) -> Result<((SignatureAlgorithm, MessageDigest), AsymmetricSignature), CoseError> {
+    match attrs.policy.permitted_algorithms {
+        Algorithm::AsymmetricSignature(alg @ AsymmetricSignature::Ecdsa { hash_alg }) => {
+            match hash_alg {
+                SignHash::Specific(Hash::Sha256) => {
+                    Ok(((SignatureAlgorithm::ES256, MessageDigest::Sha256), alg))
+                }
+                SignHash::Specific(Hash::Sha384) => {
+                    Ok(((SignatureAlgorithm::ES384, MessageDigest::Sha384), alg))
+                }
+                SignHash::Specific(Hash::Sha512) => {
+                    Ok(((SignatureAlgorithm::ES512, MessageDigest::Sha512), alg))
+                }
+                _ => Err(CoseError::UnsupportedError(format!(
+                    "Hash algorithm {:?} is not supported",
+                    hash_alg
+                ))),
+            }
+        }
+        _ => Err(CoseError::UnsupportedError(format!(
+            "Key algorithm {:?} is not supported",
+            attrs.policy.permitted_algorithms
+        ))),
+    }
+}
+
+impl SigningPublicKey for ParsecKey {
+    fn get_parameters(&self) -> Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+        Ok(self.parameters)
+    }
+
+    fn verify(&self, digest: &[u8], signature: &[u8]) -> Result<bool, CoseError> {
+        match self
+            .parsec_client
+            .psa_verify_hash(&self.name, digest, self.algorithm, signature)
+        {
+            Ok(()) => Ok(true),
+            Err(Error::Service(ResponseStatus::PsaErrorInvalidSignature)) => Ok(false),
+            Err(e) => Err(CoseError::ParsecError(e)),
+        }
+    }
+}
+
+impl SigningPrivateKey for ParsecKey {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, CoseError> {
+        Ok(self
+            .parsec_client
+            .psa_sign_hash(&self.name, data, self.algorithm)?)
+    }
+}
+
+impl From<Error> for CoseError {
+    fn from(err: Error) -> CoseError {
+        CoseError::ParsecError(err)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,9 @@ pub enum CoseError {
     /// TPM error occured
     #[cfg(feature = "key_tpm")]
     TpmError(tss_esapi::Error),
+    /// PARSEC error occured
+    #[cfg(feature = "key_parsec")]
+    ParsecError(parsec_client::error::Error),
 }
 
 impl fmt::Display for CoseError {
@@ -51,6 +54,8 @@ impl fmt::Display for CoseError {
             CoseError::EncryptionError(e) => write!(f, "Encryption error: {}", e),
             #[cfg(feature = "key_tpm")]
             CoseError::TpmError(e) => write!(f, "TPM error: {}", e),
+            #[cfg(feature = "key_parsec")]
+            CoseError::ParsecError(e) => write!(f, "Parsec error: {}", e),
         }
     }
 }


### PR DESCRIPTION
Adding support for storing signing/verification key pairs using the
Parsec service.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>